### PR TITLE
Feature#41: Add Redirection to HomePage. Fix overlapping of course contents.

### DIFF
--- a/src/components/CoursesGrid.js
+++ b/src/components/CoursesGrid.js
@@ -37,7 +37,7 @@ const CoursesGrid = ({ className = "", courseType, courseDuration, courseTitle, 
           </b>
         </div>
         <div className="self-stretch flex flex-col items-start justify-start gap-[17px] text-lg">
-          <p className="self-stretch h-[102px] relative tracking-[0.02em] leading-[180%] inline-block shrink-0 z-[1]">
+          <p className="self-stretch h-[170px] relative tracking-[0.02em] leading-[180%] inline-block shrink-0 z-[1]">
             {courseDescription}
           </p>
           <div className="self-stretch flex flex-row items-end justify-between gap-[20px] text-black mq450:flex-wrap">

--- a/src/pages/AllCourses.js
+++ b/src/pages/AllCourses.js
@@ -3,8 +3,23 @@ import CoursesGrid from "../components/CoursesGrid";
 function AllCourses(){
     return(
         <>
+      <header>
+      <div className="flex flex-col items-start justify-start pt-[20px] px-5 pb-10 relative bg-black">
+            <a href="https://v-learn-up-e-learning-hub.vercel.app/" className="[text-decoration:none] relative tracking-[0.04em] font-bold text-[2.5rem] whitespace-nowrap z-[2] text-white">
+              VLearnUp
+            </a>
+            <img
+              className="absolute -top-[10px] -left-[0px] w-[93.8px] h-[83.2px] z-[1] pt-[15px]"
+              loading="lazy"
+              alt=""
+              src="/group-453.svg"
+            />
+          </div>
+      </header>
+
+      <div className="pt-[50px]">
         <center>
-        <h1 className='display-1'> All Courses</h1>
+        <h1 className='display-1 text-[2.5rem]'> All Courses</h1>
         </center>
         <div className="w-[1680px] flex flex-row items-start justify-start py-0 px-[17px] box-border max-w-full text-sm text-slategray-100">
         <div className="flex-1 grid flex-row items-start justify-start gap-[50px] max-w-full grid-cols-[repeat(4,_minmax(280px,_1fr))] mq850:gap-[25px] mq850:grid-cols-[minmax(280px,_1fr)] mq1500:justify-center mq1500:grid-cols-[repeat(2,_minmax(280px,_486px))]">
@@ -67,7 +82,7 @@ function AllCourses(){
 
 
 
-            <div className="shadow-[0px_18.8px_47.08px_rgba(47,_50,_125,_0.1)] rounded-xl bg-white flex flex-col items-end justify-start pt-5 px-[18px] pb-[34.8px] box-border gap-[20px] max-w-full mq850:pb-[23px] mq850:box-border">
+            <div className="shadow-[0px_18.8px_47.08px_rgba(47,_50,_125,_0.1)] rounded-xl bg-white flex flex-col items-end justify-start pt-5 px-[18px] pb-[34.8px] box-border gap-[20px] h-[700px] max-w-full mq850:pb-[23px] mq850:box-border">
               <div className="w-[374px] h-[617px] relative shadow-[0px_18.8px_47.08px_rgba(47,_50,_125,_0.1)] rounded-xl bg-white hidden max-w-full" />
               <div className="self-stretch flex flex-row items-start justify-start relative max-w-full">
                 <div className="h-[239px] flex-1 relative max-w-full">
@@ -170,6 +185,7 @@ function AllCourses(){
                 </div>
               </div>
               <CoursesGrid courseType='course' courseDuration='1 months' courseTitle='Maven: A build management tool.' courseDescription='Learn the core concepts of Maven, including Maven life cycle phases, Maven Project Coordinates, Plugins, Goals, and Repositories.' courseInstructor='Shriranga Rao' courseActualPrice='$120' courseDiscountPrice='$100'/>
+            </div>
             </div>
             </div>
             </div>


### PR DESCRIPTION
I have added Redirection to 'HomePage' from 'All Courses' page. I have added VLearnUp logo, which upon clicking redirects to 'HomePage'. I have fixed issue: overlapping course contents.
![image](https://github.com/user-attachments/assets/2d0af1e6-9c64-4a9e-9eff-bab41f824ddc)

![image](https://github.com/user-attachments/assets/94f8b55b-768c-4af2-94ea-bcbeed1ab370)



I have not added anything else to navbar of 'All Courses' Page, other than VLearnUp logo. This is just to ensure that any related links can be added in future upon requirement rather than over-engineering that at present.
